### PR TITLE
check for the blocks object and combine the namespace with the name

### DIFF
--- a/bin/theme-json.js
+++ b/bin/theme-json.js
@@ -52,6 +52,15 @@ async function processMatch(result, root, filePath, parser) {
 	const fullPath = join(root, filePath);
 	const what = await parseFile(fullPath, parser);
 	const where = getKey(filePath);
+	// if we are in the blocks directory, we need to combine the block namespace and name into one key
+	const inBlocksObject = where[1] === "blocks";
+	if (inBlocksObject) {
+		// if the file is in the blocks directory, we need to add the block name to the key
+		const blockNamespace = where[2];
+		const blockName = where[3];
+		where[2] = `${blockNamespace}/${blockName}`;
+		where.splice(3, 1);
+	}
 	set(result, where, what);
 	return result;
 }


### PR DESCRIPTION
Closes #65 

Inside the `blocks` folder, the `theme-json` compiler will always combine the first folder (which should be the block namespace) with the filename:

`blocks/` > `core.` > `quote.jsonc` becomes:

```json
"blocks": {
    "core/quote": {}
}
```