### PR TITLE
Group Block Parity with front-end/editor

### DIFF
--- a/src/scss/blocks/core/group.scss
+++ b/src/scss/blocks/core/group.scss
@@ -1,5 +1,8 @@
 .wp-block-group {
 	// padding added for parity with the block editor
-	padding-bottom: 1.25em;
-	padding-top: 1.25em;
+	padding-bottom: 0;
+	padding-top: 0;
+	&.is-selected, &.has-child-selected {
+		padding-bottom: 1.25em
+	}
 }


### PR DESCRIPTION
Closes #79

Okay so the group block has some extra padding in the Block Editor to help you easily add more child blocks. However, that creates a false sense of what the block _actually_ looks like on the front end.

To fix that, I've added a bit of bottom padding to the group block _only_ if the group block is selected or one of its child blocks are selected.

## Unselected group block in the editor

<img width="783" alt="Screen Shot 2023-02-21 at 4 45 34 PM" src="https://user-images.githubusercontent.com/6925260/220484262-c355924d-8cde-4d50-80ac-9d02b1fe0a23.png">

## Selected group block in the editor

<img width="748" alt="Screen Shot 2023-02-21 at 4 45 56 PM" src="https://user-images.githubusercontent.com/6925260/220484327-27cd6dd8-429b-461d-bf36-003090080183.png">
