### PR TITLE
Add padding to `.is-layout-flow` so child elements will align correctly

### DIFF
--- a/src/scss/utilities/container.scss
+++ b/src/scss/utilities/container.scss
@@ -21,7 +21,7 @@
 	@extend .flow;
 	padding-right: props.style("root", "padding-right");
 	padding-left: props.style("root", "padding-left");
-	& > * {
+	& > *, .is-layout-flow > * {
 		@include mixins.margin-x(auto);
 		max-width: props.custom("content-sizes", "default");
 		&:where(.alignfull) {
@@ -42,5 +42,9 @@
 			float: right;
 			margin-left: props.style("block-gap");
 		}
+	}
+	.is-layout-flow > * {
+		padding-right: props.style("root", "padding-right");
+		padding-left: props.style("root", "padding-left");
 	}
 }


### PR DESCRIPTION
So turns out the only thing we really need to do is affect `.is-layout-flow`. I added the same padding we gave `.entry-content` so that child elements' alignment behaves the way we want it to. And of course, include `.is-layout-flow` in the alignment settings class as well.

Closes #33 