### PR TITLE
DRAFT Adds block.json schema

### DIFF
--- a/src/blocks/hello-world/block.json
+++ b/src/blocks/hello-world/block.json
@@ -9,8 +9,8 @@
 	"textdomain": "tangent",
 	"attributes": {
 		"content": {
-			"selector": "hello-world-text",
-			"type": "string"
+			"type": "string",
+			"selector": "hello-world-text"
 		},
 		"img": {
 			"type": "object"


### PR DESCRIPTION
Closes #131

One issue @aurooba - we need a `type` for the content attribute. I believe it's a `string` but wanted to confirm.