### PR TITLE
Add helper function to enqueue block assets in a template

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -196,12 +196,19 @@ add_action( 'init', 'Tangent\Enqueue\register_blocks' );
  * Heavily inspired by the Core function wp_enqueue_registered_block_scripts_and_styles()
  * See: https://developer.wordpress.org/reference/functions/wp_enqueue_registered_block_scripts_and_styles/
  *
- * @param array $blocks An array of namespaced block names. (e.g. core/group)
+ * @param string|array $blocks The block name(s) to enqueue assets for, e.g. 'core/group'. Accepts a single block name or an array of block names.
  *
  * @return void
  */
 function selectively_enqueue_block_assets( $blocks ) {
 	$block_registry = \WP_Block_Type_Registry::get_instance();
+
+	// If passed a single block name, convert it to an array.
+	if ( ! is_array( $blocks ) ) {
+		$blocks = array( $blocks );
+	}
+
+	// Enqueue assets for each block.
 	foreach ( $blocks as $block ) {
 		$block_type = $block_registry->get_registered( $block );
 		if ( ! $block_type ) {


### PR DESCRIPTION
Closes #118 

Here's a way to test:

Somewhere in your footer, add this code for a cover block: 
```html
	<div class="wp-block-cover">
		<span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span>
		<div class="wp-block-cover__inner-container">
			<p class="has-text-align-center has-large-font-size">test cover</p>
		</div>
	</div>
```

The footer shouldn't show the green background colour, because the `core/cover` styles don't exist on the page (I'm assuming you don't have a cover block on the page when you add this).

Now, add the following to your footer.php file at the top:

```php
Tangent\Enqueue\selectively_enqueue_block_assets( array( 'core/cover' ) );
```

The cover styles should appear! It enqueues not only any styles but also any frontend javascript that may be associated with the blocks requested.

# Testing Locations

- [x] in a dynamic block `render.php`
- [x] shortcode
- [x] The Loop
- [x] Footer
- [x] Header