### PR TITLE
Move `removeEditorPanel` into domReady area

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -27,7 +27,9 @@ const unregisterBlocks = [
  * @type {Array} Add the names of panels to remove here
  * @see https://developer.wordpress.org/block-editor/reference-guides/data/data-core-edit-post/#removeeditorpanel
  */
-const removeEditorPanels = ["discussion-panel"];
+const removeEditorPanels = [
+	//"discussion-panel"
+];
 
 /**
  * Remove block styles


### PR DESCRIPTION
Closes #145 

We have to check if we are in the post editor or not _after_ the `DOM` is fully loaded, otherwise the `removeEditorPanel` function won't be available. So I've moved the destructuring of that function into the `domReady` area.