### PR TITLE
Fix props function in `flow.scss`

### DIFF
--- a/src/scss/utils/flow.scss
+++ b/src/scss/utils/flow.scss
@@ -1,6 +1,6 @@
 @use "props" as *;
 .flow {
 	& > * + * {
-		margin-top: style("block-gap", null, 1rem);
+		margin-top: ref("style.blockGap");
 	}
 }


### PR DESCRIPTION
Found a bug. The props function in `flow.scss` hadn't been updated to the new `ref` function.