### PR TITLE
Remove themejson generator from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"scripts": {
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
-		"build": "npm run themejson && wp-scripts build --config ./bin/webpack.config.js  --webpack-src-dir=src/blocks",
+		"build": "wp-scripts build --config ./bin/webpack.config.js --webpack-src-dir=src/blocks",
 		"dev:compile": "wp-scripts start --config ./bin/webpack.config.js --webpack-src-dir=src/blocks --no-watch",
 		"start": "nodemon --watch ./src --ext js,css,scss,jsonc,php,json --exec \"npm run dev:compile\""
 	}


### PR DESCRIPTION
closes #181 

Since the theme-json generator has been converted into a webpack loader and included in the webpack config, we don't need to run it separately anymore.