### PR TITLE
Updates phpcs workflow to checkout v3

### DIFF
--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -7,6 +7,6 @@ jobs:
       name: WPCS
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: WPCS check
           uses: 10up/wpcs-action@stable


### PR DESCRIPTION
This - if it works- should clear up the node warning in the actions area.