### PR TITLE
adjust fade mixin

### DIFF
--- a/src/scss/utils/mixins.scss
+++ b/src/scss/utils/mixins.scss
@@ -43,9 +43,9 @@
 
 /// Simple fade-in animation
 /// @param {String} $type - "show" or "hide", defaults to "show"
+/// @param {Number} $delay - Animation delay in seconds
 /// @param {Number} $duration - Animation duration in seconds
 /// @param {String} $timing-function - Animation timing function, defaults to "ease-in"
-/// @param {Number} $delay - Animation delay in seconds
 @mixin fade(
 	$type: "show",
 	$delay: 0s,


### PR DESCRIPTION
Closes #207

The fade mixin has been adjusted so it's _actually_ useful. Not only does it now default to `show`  for the initial `type` parameter (for fading things _in_) it also has:
- a `delay` parameter (that defaults to `0s`)
- a `duration` parameter (that defaults to `0.5s`) and 
- a `timing-function` parameter (that defaults to `ease-in`).

To test:

1. Add `@include utils.fade();` in `header.scss` to #masthead and see that it fades in.
2. Switch it to `@include utils.fade('hide', 1s );` to see that it fades the header out.