### PR TITLE
Check if location has a nav assigned before rendering the header nav

### DIFF
--- a/template-parts/navigation-offcanvas.php
+++ b/template-parts/navigation-offcanvas.php
@@ -6,7 +6,10 @@
  */
 
 ?>
-
+<?php
+// don't render the navigation if no menu is assigned.
+if ( has_nav_menu( 'menu-1' ) ) {
+	?>
 <nav id="site-navigation" class="offcanvas-navigation">
 
 	<button class="menu-toggle link-button" aria-haspopup="true" data-micromodal-trigger="navigation-modal" aria-label="<?php esc_html_e( 'Primary Menu', 'tangent' ); ?>">
@@ -26,7 +29,6 @@
 				</header>
 
 				<?php
-				if ( has_nav_menu( 'menu-1' ) ) {
 					wp_nav_menu(
 						array(
 							'theme_location'  => 'menu-1',
@@ -37,10 +39,10 @@
 							'walker'          => new Tangent\Navwalker\Tangent_Navwalker(),
 						)
 					);
-				}
 				?>
 
 			</div>
 		</div>
 	</div>
 </nav>
+<?php } ?>


### PR DESCRIPTION
Closes #205 

Not 100% sure why having a custom nav walker makes the fallback walker not function correctly, but in any case, the simplest fix is to not render the nav if there's no menu assigned to the location.