### PR TITLE
use `__NAMESPACE__` in hooks

### DIFF
--- a/inc/enqueue-blocks.php
+++ b/inc/enqueue-blocks.php
@@ -39,7 +39,7 @@ function enqueue_block_specific_styles() {
 	}
 }
 
-add_action( 'after_setup_theme', 'Tangent\Enqueue\Blocks\enqueue_block_specific_styles' );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\enqueue_block_specific_styles' );
 
 /**
  * Get all the Block Specific CSS files in the css/ folder.
@@ -49,7 +49,7 @@ add_action( 'after_setup_theme', 'Tangent\Enqueue\Blocks\enqueue_block_specific_
  */
 function get_block_specific_stylesheets() {
 	$get_all_css_files = glob( get_stylesheet_directory() . '/css/*.css' );
-	$css_files         = array_reduce( $get_all_css_files, 'Tangent\Enqueue\Blocks\associative_array_of_blocks_and_stylesheet_args', array() );
+	$css_files         = array_reduce( $get_all_css_files, __NAMESPACE__ . '\associative_array_of_blocks_and_stylesheet_args', array() );
 	return $css_files;
 }
 
@@ -98,7 +98,7 @@ function register_blocks() {
 	}
 }
 
-add_action( 'init', 'Tangent\Enqueue\Blocks\register_blocks' );
+add_action( 'init', __NAMESPACE__ . '\register_blocks' );
 
 /**
  * Enqueue assets for blocks when specifically requested.

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -20,7 +20,7 @@ function global_theme_styles() {
 
 	wp_enqueue_style( 'tangent-global-theme-style', get_template_directory_uri() . '/css/global.css', array(), $css_version );
 }
-add_action( 'wp_enqueue_scripts', 'Tangent\Enqueue\global_theme_styles' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\global_theme_styles' );
 
 /**
  * Enqueue the `scripts.js` file and associated dependencies.
@@ -36,7 +36,7 @@ function front_end_scripts() {
 
 	wp_enqueue_script( 'tangent-front-end-scripts', get_template_directory_uri() . '/js/scripts.js', $dependencies, $asset_file['version'], true );
 }
-add_action( 'wp_enqueue_scripts', 'Tangent\Enqueue\front_end_scripts' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\front_end_scripts' );
 
 /**
  * Enqueue editor specific modifications in the Post Editor, Site Editor,
@@ -70,7 +70,7 @@ function enqueue_editor_modifications() {
 	wp_enqueue_script( 'tangent-editor-modifications', get_template_directory_uri() . '/js/editor.js', $dependencies, $asset_file['version'], true );
 }
 
-add_action( 'enqueue_block_editor_assets', 'Tangent\Enqueue\enqueue_editor_modifications' );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_editor_modifications' );
 
 /**
  * Enqueue the `comment-reply` script if threaded comments are enabled.
@@ -83,7 +83,7 @@ function enqueue_threaded_comment_reply() {
 	}
 }
 
-add_action( 'comment_form_before', 'Tangent\Enqueue\enqueue_threaded_comment_reply' );
+add_action( 'comment_form_before', __NAMESPACE__ . '\enqueue_threaded_comment_reply' );
 
 /**
  * Enqueue the `editor.css` file in the Block Editor.
@@ -93,4 +93,4 @@ add_action( 'comment_form_before', 'Tangent\Enqueue\enqueue_threaded_comment_rep
 function add_editor_styles() {
 	add_editor_style( 'css/editor.css' );
 }
-add_action( 'after_setup_theme', 'Tangent\Enqueue\add_editor_styles' );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\add_editor_styles' );

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -121,7 +121,7 @@ function theme_setup() {
 	 * );
 	 */
 }
-add_action( 'after_setup_theme', 'Tangent\Setup\theme_setup' );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_setup' );
 
 /**
  * Custom login logo
@@ -146,7 +146,7 @@ function custom_login_logo() {
 		<?php
 	}
 }
-add_action( 'login_enqueue_scripts', 'Tangent\Setup\custom_login_logo' );
+add_action( 'login_enqueue_scripts', __NAMESPACE__ . '\custom_login_logo' );
 
 
 /**
@@ -155,4 +155,4 @@ add_action( 'login_enqueue_scripts', 'Tangent\Setup\custom_login_logo' );
 function custom_login_link() {
 	return home_url();
 }
-add_filter( 'login_headerurl', 'Tangent\Setup\custom_login_link' );
+add_filter( 'login_headerurl', __NAMESPACE__ . '\custom_login_link' );


### PR DESCRIPTION
Closes #187

Just replaces hard coded namespaces in hooks with `__NAMESPACE__`