### PR TITLE
Remove nodemon secondary watch process

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,11 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^27.6.0",
 		"glob": "^8.1.0",
-		"nodemon": "^3.1.0",
 		"remove-files-webpack-plugin": "^1.5.0"
 	},
 	"scripts": {
-		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"build": "wp-scripts build --config ./bin/webpack.config.js --webpack-src-dir=src/blocks",
 		"create-block": "cd ./src/blocks && npx @wordpress/create-block --namespace=block-theme --no-plugin --variant=dynamic",
-		"dev:compile": "wp-scripts start --config ./bin/webpack.config.js --webpack-src-dir=src/blocks --no-watch",
-		"start": "nodemon --watch ./src --ext js,css,scss,php,json --exec \"npm run dev:compile\""
+		"start": "wp-scripts start --config ./bin/webpack.config.js --webpack-src-dir=src/blocks"
 	}
 }

--- a/src/scss/base/typography.scss
+++ b/src/scss/base/typography.scss
@@ -4,5 +4,5 @@ small {
 
 ul,
 ol {
-	padding: 0 0 0 var(--wp--preset--spacing--md);
+	padding: 0 0 0 var(--wp--preset--spacing--50);
 }

--- a/src/scss/blocks/core/quote.scss
+++ b/src/scss/blocks/core/quote.scss
@@ -1,4 +1,4 @@
 .wp-block-quote {
 	border-left: 2px solid var(--wp--preset--color--primary);
-	padding-left: var(--wp--preset--spacing--md);
+	padding-left: var(--wp--preset--spacing--50);
 }


### PR DESCRIPTION
By reverting back to the original wp-scripts watch (since we're not concerned with the jsonc partials) the dev compile process is about 5x faster now.