### PR TITLE
Removes unnecessary duotone fix

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -25,17 +25,6 @@ function theme_setup() {
 	 * @link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#disabling-the-default-block-patterns
 	 */
 	remove_theme_support( 'core-block-patterns' );
-
-	/**
-	 * Remove duotone filter SVGs from loading on the frontend if default
-	 * and custom duotones are disabled.
-	 */
-	$theme_json_color_settings = wp_get_global_settings( array( 'color' ) );
-
-	if ( ! $theme_json_color_settings['customDuotone'] && ! $theme_json_color_settings['defaultDuotone'] ) {
-		remove_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
-		remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
-	}
 }
 add_action( 'after_setup_theme', __NAMESPACE__ . '\theme_setup' );
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,6 @@ Most of the theme setup is handled in the `inc/*.php` files. This includes:
 - Enqueueing scripts and styles, including block-specific styles
 - Any custom theme options
 - Replacing the WordPress Logo and colors on the login screen with the site logo and colors
-- Removing duotone SVG filters from loading on the frontend
 
 ## Theme.json
 


### PR DESCRIPTION
In previous versions of WP the SVG filters for duotones were loaded sitewide, but that's not the case any more

https://developer.wordpress.org/reference/functions/wp_global_styles_render_svg_filters/