### PR TITLE
Adds a hotfix to remove php notice on rtl stylesheets

### DIFF
--- a/inc/enqueue-blocks.php
+++ b/inc/enqueue-blocks.php
@@ -66,7 +66,7 @@ function get_block_specific_stylesheets() {
 function associative_array_of_blocks_and_stylesheet_args( $accumulator, $css_file ) {
 	// Hard coded values to exclude certain stylesheets.
 	// TODO: Make this dynamic or provide a way to exclude stylesheets through /setup.php.
-	$exclude_stylesheets = array( 'global.css', 'editor.css' );
+	$exclude_stylesheets = array( 'global.css', 'global-rtl.css', 'editor.css', 'editor-rtl.css' );
 
 	if ( in_array( basename( $css_file ), $exclude_stylesheets, true ) ) {
 		return $accumulator;

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ As of now, this repository does _not_ include the final built assets or blocks. 
 
 `npm run build` will build the theme's CSS and JavaScript files.
 
-`npm run watch` will watch for changes to the theme's SCSS and JavaScript files partials and rebuild them automatically.
+`npm run start` will watch for changes to the theme's SCSS and JavaScript files partials and rebuild them automatically.
 
 One note is that `@wordpress/scripts` is not great at recognizing _new_ files in the `src` directory. If you add a new file, you may need to restart the build process.
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,9 @@ BlockTheme does enqueue two global stylesheets, one for the frontend (`global.cs
 
 #### Utils/Mixins
 
-There are a few mixins and functions in the `src/scss/utils` directory that you can use in any of your SCSS files by importing them. An example:
+There are a few mixins and functions in the `src/scss/utils` directory that you can use in any of your SCSS files by importing them. This includes any `style.scss`, `editor.scss`, or `view.scss` file in a custom block. 
+
+An example:
 
 ```scss
 @use '../utils';


### PR DESCRIPTION
I need more thought on whether or not to compile RTL stylesheets for editor/global, but for now, we'll just run a fix so the PHP notice goes away. 

With this PR the stylesheets are still generated for those screens, but not enqueued. But at least rtl blocks and block styles should work.

Related #258